### PR TITLE
Actions fix

### DIFF
--- a/.github/workflows/phpcs_on_pull_request.yml
+++ b/.github/workflows/phpcs_on_pull_request.yml
@@ -7,11 +7,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Install Dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y git sudo
-
     - uses: actions/checkout@v4
       with:
         ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/release_on_tag.yml
+++ b/.github/workflows/release_on_tag.yml
@@ -54,14 +54,15 @@ jobs:
           echo "=== Plugin zip contents ==="
           unzip -l $GITHUB_WORKSPACE/onedesign.zip
 
-      - name: Upload Release Artifact
+      - name: Upload Release Artifact with gh CLI
         if: startsWith(github.ref, 'refs/tags/dry') == false && github.ref != 'refs/heads/develop'
-        uses: softprops/action-gh-release@v2.3.2
-        with:
-          files: |
-            ${{ steps.create-zip.outputs.zip-path }}
-          token: '${{ github.token }}'
-          tag_name: ${{ github.ref_name }}
-          draft: true
-          generate_release_notes: true
-          name: OneDesign ${{ github.ref_name }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release view "${{ github.ref_name }}" || \
+            gh release create "${{ github.ref_name }}" \
+              --title "OneDesign ${{ github.ref_name }}" \
+              --notes "" \
+              --draft
+          # Upload the artifact
+          gh release upload "${{ github.ref_name }}" "${{ steps.create-zip.outputs.zip-path }}" --clobber

--- a/.github/workflows/release_on_tag.yml
+++ b/.github/workflows/release_on_tag.yml
@@ -10,12 +10,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install system dependencies
-        shell: bash
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y zip unzip composer
-
       - name: Set up Node
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/release_on_tag.yml
+++ b/.github/workflows/release_on_tag.yml
@@ -62,7 +62,7 @@ jobs:
           gh release view "${{ github.ref_name }}" || \
             gh release create "${{ github.ref_name }}" \
               --title "OneDesign ${{ github.ref_name }}" \
-              --notes "" \
+              --generate-notes \
               --draft
           # Upload the artifact
           gh release upload "${{ github.ref_name }}" "${{ steps.create-zip.outputs.zip-path }}" --clobber


### PR DESCRIPTION
This pull request makes a small update to the GitHub Actions workflow by removing the step that installs system dependencies such as `zip`, `unzip`, and `composer` from the `.github/workflows/release_on_tag.yml` file. This change simplifies the workflow and may reduce build times.