### PR TITLE
Fix: QA issue after code refactoring

### DIFF
--- a/assets/src/admin/patterns/components/SiteSelection.js
+++ b/assets/src/admin/patterns/components/SiteSelection.js
@@ -93,10 +93,12 @@ const SiteSelection = ( {
 			} )
 			.map( ( site ) => site.id );
 
+		setIsSiteSelected( selectableSiteIds.length > 0 );
 		editPost( { meta: { brand_site: selectableSiteIds } } );
 	};
 
 	const deselectAllSites = () => {
+		setIsSiteSelected( false );
 		editPost( { meta: { brand_site: [] } } );
 	};
 

--- a/assets/src/components/SiteModal.js
+++ b/assets/src/components/SiteModal.js
@@ -110,12 +110,13 @@ const SiteModal = ( { formData, setFormData, onSubmit, onClose, editing, origina
 		try {
 			// Perform health-check
 			const healthCheck = await fetch(
-				`${ formData.url }/wp-json/onedesign/v1/health-check`,
+				`${ formData.url }/wp-json/onedesign/v1/health-check?timestamp=${ Date.now() }`,
 				{
 					method: 'GET',
 					headers: {
 						'Content-Type': 'application/json',
 						'X-OneDesign-Token': formData.api_key,
+						'X-OneDesign-Source': 'Settings',
 					},
 				},
 			);

--- a/assets/src/hooks/useSitesManagement.js
+++ b/assets/src/hooks/useSitesManagement.js
@@ -38,6 +38,7 @@ const useSitesManagement = ( { NONCE, API_NAMESPACE } ) => {
 								headers: {
 									'Content-Type': 'application/json',
 									'X-OneDesign-Token': siteApiKey,
+									'X-OneDesign-Source': 'Patterns-Templates-Sharing',
 								},
 							},
 						);

--- a/inc/Modules/Core/Rest.php
+++ b/inc/Modules/Core/Rest.php
@@ -40,6 +40,7 @@ final class Rest implements Registrable {
 			$headers,
 			[
 				'X-OneDesign-Token',
+				'X-OneDesign-Source',
 			]
 		);
 	}

--- a/inc/Modules/Core/Rest.php
+++ b/inc/Modules/Core/Rest.php
@@ -31,17 +31,21 @@ final class Rest implements Registrable {
 	 * @return array<int, string> Modified headers.
 	 */
 	public function allowed_cors_headers( $headers ): array {
-		// Skip if the headers are already present.
-		if ( in_array( 'X-OneDesign-Token', $headers, true ) ) {
-			return $headers;
+
+		$headers_to_add = [
+			'X-OneDesign-Token',
+			'X-OneDesign-Source',
+		];
+
+		// Only add headers that aren't already present.
+		foreach ( $headers_to_add as $header ) {
+			if ( in_array( $header, $headers, true ) ) {
+				continue;
+			}
+
+			$headers[] = $header;
 		}
 
-		return array_merge(
-			$headers,
-			[
-				'X-OneDesign-Token',
-				'X-OneDesign-Source',
-			]
-		);
+		return $headers;
 	}
 }

--- a/inc/Modules/Rest/Abstract_REST_Controller.php
+++ b/inc/Modules/Rest/Abstract_REST_Controller.php
@@ -101,6 +101,14 @@ abstract class Abstract_REST_Controller extends \WP_REST_Controller implements R
 		// If it's a healthcheck with no governing site, allow it and set the governing site.
 		if ( empty( $governing_site_url ) ) {
 			if ( '/' . $this->namespace . '/health-check' === $request->get_route() ) {
+
+				// Need to check x-onedesign-source header to confirm request source is from settings page as we are performing health check before sharing patterns/templates.
+				$source = $request->get_header( 'X_ONEDESIGN_SOURCE' );
+				$source = ! empty( $source ) ? sanitize_text_field( wp_unslash( $source ) ) : '';
+				if ( 'Settings' !== $source ) {
+					return false;
+				}
+
 				Settings::set_parent_site_url( $request_origin );
 				return true;
 			}


### PR DESCRIPTION
### Dev note
- instead of adding `'cache-control': 'private, max-age=0, no-cache, must-revalidate',` added query param to get request as sometimes QA has reported requests getting cached after after disconnecting site/making updates.

---

- Part of https://github.com/rtCamp/OnePress/issues/55