### PR TITLE
feat: add Playwright E2E testing scaffold

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -258,15 +258,15 @@ jobs:
           max_attempts: 3
           command: |
             if [ "${{ matrix.coverage }}" == "true" ]; then
-            npm run wp-env start -- --xdebug=coverage
+            npm run wp-env:test start -- --xdebug=coverage
             else
-            npm run wp-env start
+            npm run wp-env:test start
             fi
 
       - name: Log versions
         run: |
-          npm run wp-env -- run cli php -- -v
-          npm run wp-env -- run cli wp core version
+          npm run wp-env:test -- run cli php -- -v
+          npm run wp-env:test -- run cli wp core version
 
       - name: Run PHPUnit tests${{ matrix.coverage && ' with coverage report' || '' }}
         id: phpunit

--- a/.wp-env.child.json
+++ b/.wp-env.child.json
@@ -2,13 +2,15 @@
 	"$schema": "https://schemas.wp.org/trunk/wp-env.json",
 
 	"core": null,
-	"port": 8889,
+	"port": 8890,
 	"testsEnvironment": false,
 	"plugins": [ ".", "./tests/_data/plugins/localhost-helper" ],
 	"config": {
 		"FS_METHOD": "direct",
+		"WP_DEVELOPMENT_MODE": "plugin",
+		"WP_ENVIRONMENT_TYPE": "development",
 		"WP_DEBUG": true,
-		"WP_DEBUG_LOG": "/var/www/html/wp-content/plugins/onedesign/tests/_output/debug-test.log"
+		"WP_DEBUG_LOG": "/var/www/html/wp-content/plugins/onedesign/tests/_output/debug-child.log"
 	},
 	"mappings": {
 		"wp-content/plugins/onedesign": "."

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,27 +1,12 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/wp-env.json",
+
 	"core": null,
-	"plugins": [
-		"./."
-	],
-	"env": {
-		"development": {
-			"config": {
-				"WP_DEVELOPMENT_MODE": "plugin",
-				"WP_DEBUG_LOG": "/var/www/html/wp-content/plugins/onedesign/tests/_output/debug.log"
-			}
-		},
-		"tests": {
-			"config": {
-				"FS_METHOD": "direct"
-			},
-			"plugins": [
-				"."
-			],
-			"mappings": {
-				"/wp-content/plugins/onedesign": "."
-			}
-		}
+	"testsEnvironment": false,
+	"plugins": [ "./.", "./tests/_data/plugins/localhost-helper" ],
+	"config": {
+		"WP_DEVELOPMENT_MODE": "plugin",
+		"WP_DEBUG_LOG": "/var/www/html/wp-content/plugins/onedesign/tests/_output/debug.log"
 	},
 	"lifecycleScripts": {
 		"afterStart": "wp-env run cli wp rewrite structure /%postname%/ --hard"

--- a/.wp-env.test.json
+++ b/.wp-env.test.json
@@ -1,0 +1,16 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/wp-env.json",
+
+	"core": null,
+	"port": 8889,
+	"testsEnvironment": false,
+	"plugins": [ "." ],
+	"config": {
+		"FS_METHOD": "direct",
+		"WP_DEBUG": true,
+		"WP_DEBUG_LOG": "/var/www/html/wp-content/plugins/onedesign/tests/_output/debug-test.log"
+	},
+	"mappings": {
+		"wp-content/plugins/onedesign": "."
+	}
+}

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -233,9 +233,11 @@ The WordPress development site will be available at <http://localhost:8888> and 
 
 #### Accessing the Local Environment
 
-- `npm run wp-env start`: Start the local development environment.
+- `npm run wp-env start`: Start the governing site environment (port 8888).
+- `npm run wp-env:child start`: Start the brand/child site environment (port 8890).
+- `npm run wp-env:test start`: Start the isolated test environment (port 8889).
 - `npm run wp-env stop`: Stop the local development environment.
-- `npm run wp-env run tests-cli YOUR_CMD_HERE`: Run WP-CLI commands in the local environment.
+- `npm run wp-env run cli -- --env-cwd=wp-content/plugins/onedesign YOUR_CMD_HERE`: Run WP-CLI or PHP tooling in the local environment.
 
 For more information on using `wp-env`, see the [wp-env documentation](https://developer.wordpress.org/block-editor/packages/packages-env/).
 
@@ -278,7 +280,7 @@ npm run test:php
 To generate a code coverage report, make sure to start the testing environment with coverage mode enabled:
 
 ```bash
-npm run wp-env start -- --xdebug=coverage
+npm run wp-env:test start -- --xdebug=coverage
 
 npm run test:php
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
 			},
 			"devDependencies": {
 				"@babel/core": "^7.29.0",
+				"@playwright/test": "^1.61.0",
 				"@testing-library/jest-dom": "^6.9.1",
 				"@testing-library/react": "^16.3.2",
 				"@types/jest": "^29.5.14",
@@ -31,7 +32,8 @@
 				"@typescript-eslint/parser": "^8.61.1",
 				"@wordpress/babel-preset-default": "^8.48.1",
 				"@wordpress/browserslist-config": "^6.40.0",
-				"@wordpress/env": "^10.39.0",
+				"@wordpress/e2e-test-utils-playwright": "1.46.0",
+				"@wordpress/env": "^11.8.0",
 				"@wordpress/eslint-plugin": "^25.4.1",
 				"@wordpress/prettier-config": "^4.48.0",
 				"@wordpress/scripts": "^32.4.1",
@@ -2734,40 +2736,6 @@
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			}
 		},
-		"node_modules/@eslint/config-array/node_modules/balanced-match": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true
-		},
-		"node_modules/@eslint/config-array/node_modules/brace-expansion": {
-			"version": "1.1.18",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
-			"integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
-		"node_modules/@eslint/config-array/node_modules/minimatch": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-			"dev": true,
-			"license": "ISC",
-			"peer": true,
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
 		"node_modules/@eslint/config-helpers": {
 			"version": "0.4.2",
 			"resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
@@ -2860,26 +2828,6 @@
 			"license": "Python-2.0",
 			"peer": true
 		},
-		"node_modules/@eslint/eslintrc/node_modules/balanced-match": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true
-		},
-		"node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-			"version": "1.1.18",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
-			"integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
 		"node_modules/@eslint/eslintrc/node_modules/globals": {
 			"version": "14.0.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
@@ -2936,20 +2884,6 @@
 			"dev": true,
 			"license": "MIT",
 			"peer": true
-		},
-		"node_modules/@eslint/eslintrc/node_modules/minimatch": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-			"dev": true,
-			"license": "ISC",
-			"peer": true,
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
-			}
 		},
 		"node_modules/@eslint/js": {
 			"version": "9.39.5",
@@ -6919,7 +6853,6 @@
 			"integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"playwright": "1.61.1"
 			},
@@ -10752,9 +10685,9 @@
 			}
 		},
 		"node_modules/@wordpress/e2e-test-utils-playwright": {
-			"version": "1.51.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils-playwright/-/e2e-test-utils-playwright-1.51.0.tgz",
-			"integrity": "sha512-ekxMfC8MUTf0fKjAQd2IO4m/l1jXC9NznveRf7r8ntmx9nXqd9IHOiYJcH2SBo20C53nWdA4w8+Mbqedf0qzEw==",
+			"version": "1.46.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils-playwright/-/e2e-test-utils-playwright-1.46.0.tgz",
+			"integrity": "sha512-Bls5BGRNda0Oo4biTZ/KIwO8iHBeovvfWNfrPXReIsrW1td1UqXw2Z9l0/LaP3euJZFNom2QExHCOba+8eN5lQ==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -10793,25 +10726,24 @@
 			}
 		},
 		"node_modules/@wordpress/env": {
-			"version": "10.39.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/env/-/env-10.39.0.tgz",
-			"integrity": "sha512-Hgl2RQAAzXFMqkpegGWT1/KkX88OVikRroPidWkij1WtU8p+AZniTcncWmlWqbdLdfGbPqQS5ZkqDZCzrQjgnA==",
+			"version": "11.11.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/env/-/env-11.11.0.tgz",
+			"integrity": "sha512-E4Riaan41uAcm70FFTD78Z1qtObQJwRlIyXdsr04X+mrg8XkBuHSqM1iSvgqnOpVzUuF9EYANYKF0CTm9tKW5w==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@inquirer/prompts": "^7.2.0",
-				"@wp-playground/cli": "^3.0.0",
-				"chalk": "^4.0.0",
+				"@wp-playground/cli": "^3.0.48",
+				"adm-zip": "^0.5.9",
+				"chalk": "^4.1.1",
 				"copy-dir": "^1.3.0",
 				"cross-spawn": "^7.0.6",
 				"docker-compose": "^0.24.3",
-				"extract-zip": "^1.6.7",
 				"got": "^11.8.5",
-				"js-yaml": "^3.13.1",
+				"js-yaml": "^3.15.0",
 				"ora": "^4.0.2",
 				"rimraf": "^5.0.10",
-				"simple-git": "^3.5.0",
-				"terminal-link": "^2.0.0",
+				"simple-git": "^3.24.0",
 				"yargs": "^17.3.0"
 			},
 			"bin": {
@@ -14565,16 +14497,16 @@
 			"license": "MIT"
 		},
 		"node_modules/brace-expansion": {
-			"version": "5.0.7",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-			"integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+			"version": "5.0.9",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+			"integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^4.0.2"
 			},
 			"engines": {
-				"node": "18 || 20 || >=22"
+				"node": "20 || >=22"
 			}
 		},
 		"node_modules/braces": {
@@ -15467,22 +15399,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/concat-stream": {
-			"version": "1.6.2",
-			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-			"integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-			"dev": true,
-			"engines": [
-				"node >= 0.8"
-			],
-			"license": "MIT",
-			"dependencies": {
-				"buffer-from": "^1.0.0",
-				"inherits": "^2.0.3",
-				"readable-stream": "^2.2.2",
-				"typedarray": "^0.0.6"
-			}
-		},
 		"node_modules/configstore": {
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/configstore/-/configstore-7.1.0.tgz",
@@ -15639,13 +15555,6 @@
 				"type": "opencollective",
 				"url": "https://opencollective.com/core-js"
 			}
-		},
-		"node_modules/core-util-is": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/cosmiconfig": {
 			"version": "7.1.0",
@@ -18377,26 +18286,6 @@
 				"url": "https://github.com/sponsors/epoberezkin"
 			}
 		},
-		"node_modules/eslint/node_modules/balanced-match": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true
-		},
-		"node_modules/eslint/node_modules/brace-expansion": {
-			"version": "1.1.18",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
-			"integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
 		"node_modules/eslint/node_modules/eslint-scope": {
 			"version": "8.4.0",
 			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
@@ -18481,20 +18370,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/eslint/node_modules/minimatch": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-			"dev": true,
-			"license": "ISC",
-			"peer": true,
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
 			}
 		},
 		"node_modules/eslint/node_modules/p-locate": {
@@ -18803,39 +18678,6 @@
 			"version": "0.1.13",
 			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
 			"integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/extract-zip": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.7.0.tgz",
-			"integrity": "sha512-xoh5G1W/PB0/27lXgMQyIhP5DSY/LhoCsOyZgb+6iMmRtCwVBo55uKaMoEYrDCKQhWvqEip5ZPKAc6eFNyf/MA==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"concat-stream": "^1.6.2",
-				"debug": "^2.6.9",
-				"mkdirp": "^0.5.4",
-				"yauzl": "^2.10.0"
-			},
-			"bin": {
-				"extract-zip": "cli.js"
-			}
-		},
-		"node_modules/extract-zip/node_modules/debug": {
-			"version": "2.6.9",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ms": "2.0.0"
-			}
-		},
-		"node_modules/extract-zip/node_modules/ms": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -19710,37 +19552,6 @@
 			},
 			"peerDependencies": {
 				"tslib": "2"
-			}
-		},
-		"node_modules/glob/node_modules/balanced-match": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/glob/node_modules/brace-expansion": {
-			"version": "1.1.18",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
-			"integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
-		"node_modules/glob/node_modules/minimatch": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
 			}
 		},
 		"node_modules/global-modules": {
@@ -21286,13 +21097,6 @@
 			"engines": {
 				"node": ">=8"
 			}
-		},
-		"node_modules/isarray": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/isexe": {
 			"version": "2.0.0",
@@ -24293,13 +24097,13 @@
 			}
 		},
 		"node_modules/minimatch": {
-			"version": "10.2.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-			"integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+			"version": "10.2.6",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+			"integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
 			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"dependencies": {
-				"brace-expansion": "^5.0.5"
+				"brace-expansion": "^5.0.8"
 			},
 			"engines": {
 				"node": "18 || 20 || >=22"
@@ -24494,19 +24298,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/mkdirp": {
-			"version": "0.5.6",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-			"integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"minimist": "^1.2.6"
-			},
-			"bin": {
-				"mkdirp": "bin/cmd.js"
 			}
 		},
 		"node_modules/module-details-from-path": {
@@ -26215,7 +26006,6 @@
 			"integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"playwright-core": "1.61.1"
 			},
@@ -26235,7 +26025,6 @@
 			"integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"bin": {
 				"playwright-core": "cli.js"
 			},
@@ -26254,7 +26043,6 @@
 			"os": [
 				"darwin"
 			],
-			"peer": true,
 			"engines": {
 				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}
@@ -27163,13 +26951,6 @@
 				"node": ">= 0.6.0"
 			}
 		},
-		"node_modules/process-nextick-args": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/progress": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -27833,29 +27614,6 @@
 			"bin": {
 				"semver": "bin/semver"
 			}
-		},
-		"node_modules/readable-stream": {
-			"version": "2.3.8",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-			"integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"core-util-is": "~1.0.0",
-				"inherits": "~2.0.3",
-				"isarray": "~1.0.0",
-				"process-nextick-args": "~2.0.0",
-				"safe-buffer": "~5.1.1",
-				"string_decoder": "~1.1.1",
-				"util-deprecate": "~1.0.1"
-			}
-		},
-		"node_modules/readable-stream/node_modules/safe-buffer": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/readdirp": {
 			"version": "5.0.0",
@@ -29485,23 +29243,6 @@
 				"text-decoder": "^1.1.0"
 			}
 		},
-		"node_modules/string_decoder": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"safe-buffer": "~5.1.0"
-			}
-		},
-		"node_modules/string_decoder/node_modules/safe-buffer": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/string-length": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
@@ -30508,37 +30249,6 @@
 				"streamx": "^2.12.5"
 			}
 		},
-		"node_modules/terminal-link": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
-			"integrity": "sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-escapes": "^4.2.1",
-				"supports-hyperlinks": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/terminal-link/node_modules/supports-hyperlinks": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.3.0.tgz",
-			"integrity": "sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"has-flag": "^4.0.0",
-				"supports-color": "^7.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/terser": {
 			"version": "5.49.0",
 			"resolved": "https://registry.npmjs.org/terser/-/terser-5.49.0.tgz",
@@ -31247,13 +30957,6 @@
 			"version": "2.12.2",
 			"resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.2.tgz",
 			"integrity": "sha512-EOPFbyIub4ngnEdqi2yOcNeDLaX/0jcE1JoAXQDDMIthap7FoN795lc/SHfIq2d416VufXpM8z/lD+WRm2gfOQ==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/typedarray": {
-			"version": "0.0.6",
-			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-			"integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
 			"dev": true,
 			"license": "MIT"
 		},

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
 	},
 	"devDependencies": {
 		"@babel/core": "^7.29.0",
+		"@playwright/test": "^1.61.0",
 		"@testing-library/jest-dom": "^6.9.1",
 		"@testing-library/react": "^16.3.2",
 		"@types/jest": "^29.5.14",
@@ -44,7 +45,8 @@
 		"@typescript-eslint/parser": "^8.61.1",
 		"@wordpress/babel-preset-default": "^8.48.1",
 		"@wordpress/browserslist-config": "^6.40.0",
-		"@wordpress/env": "^10.39.0",
+		"@wordpress/e2e-test-utils-playwright": "1.46.0",
+		"@wordpress/env": "^11.8.0",
 		"@wordpress/eslint-plugin": "^25.4.1",
 		"@wordpress/prettier-config": "^4.48.0",
 		"@wordpress/scripts": "^32.4.1",
@@ -80,11 +82,13 @@
 		"plugin-zip": "wp-scripts plugin-zip",
 		"start:js": "wp-scripts start --config ./webpack.config.js",
 		"start": "npm-run-all --parallel start:*",
+		"test:e2e": "wp-scripts test-playwright",
 		"test:js": "wp-scripts test-unit-js",
 		"test:js:coverage": "wp-scripts test-unit-js --coverage",
 		"test:js:watch": "wp-scripts test-unit-js --watch",
 		"test:php": "wp-env run tests-cli --env-cwd=wp-content/plugins/$(basename \"$(pwd)\")/ composer run-script test",
-		"wp-env": "wp-env"
+		"wp-env": "wp-env",
+		"wp-env:test": "wp-env --config=.wp-env.test.json"
 	},
 	"overrides": {
 		"@babel/runtime": "^7.27.6",
@@ -94,6 +98,10 @@
 		"minimatch": ">=10.2.1",
 		"serialize-javascript": ">=7.0.3",
 		"prettier": "npm:wp-prettier@^3",
+		"@wordpress/e2e-test-utils-playwright": "1.46.0",
+		"@wordpress/scripts": {
+			"@wordpress/e2e-test-utils-playwright": "1.46.0"
+		},
 		"eslint-plugin-import": {
 			"minimatch": "^3.1.2"
 		},

--- a/package.json
+++ b/package.json
@@ -86,8 +86,9 @@
 		"test:js": "wp-scripts test-unit-js",
 		"test:js:coverage": "wp-scripts test-unit-js --coverage",
 		"test:js:watch": "wp-scripts test-unit-js --watch",
-		"test:php": "wp-env run tests-cli --env-cwd=wp-content/plugins/$(basename \"$(pwd)\")/ composer run-script test",
+		"test:php": "npm run wp-env:test -- run cli --env-cwd=wp-content/plugins/$(basename \"$(pwd)\")/ vendor/bin/phpunit -c phpunit.xml.dist",
 		"wp-env": "wp-env",
+		"wp-env:child": "wp-env --config=.wp-env.child.json",
 		"wp-env:test": "wp-env --config=.wp-env.test.json"
 	},
 	"overrides": {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,27 @@
+/**
+ * External dependencies
+ */
+import { defineConfig, type PlaywrightTestConfig } from '@playwright/test';
+import path from 'path';
+
+const artifactsPath = path.join( process.cwd(), 'tests/_output/e2e' );
+
+// Ensure WP artifacts (and storage-state) are written into tests/_output
+process.env[ 'WP_ARTIFACTS_PATH' ] = artifactsPath;
+// Ensure STORAGE_STATE_PATH points into tests/_output as well
+process.env[ 'STORAGE_STATE_PATH' ] = path.join(
+	artifactsPath,
+	'storage-states',
+	'admin.json'
+);
+
+const baseConfig =
+	require( '@wordpress/scripts/config/playwright.config.js' ) as PlaywrightTestConfig;
+
+const config = defineConfig( {
+	...baseConfig,
+	testDir: './tests/e2e',
+	outputDir: './tests/_output/e2e',
+} );
+
+export default config;

--- a/tests/_data/plugins/localhost-helper/localhost-helper.php
+++ b/tests/_data/plugins/localhost-helper/localhost-helper.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Plugin Name: OneDesign - Localhost Helper
+ * Description: Rewrites localhost URLs to host.docker.internal for inter-container HTTP requests in wp-env Docker environments. Only affects URLs containing "onedesign/v1".
+ * Version: 1.0.0
+ * Author: rtCamp
+ * License: GPL-2.0-or-later
+ *
+ * @package OneDesign\Dev
+ */
+
+declare( strict_types = 1 );
+
+namespace OneDesign\Localhost_Helper;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+// Bypass URL validation for onedesign endpoints.
+add_filter( // phpcs:ignore WordPressVIPMinimum.Hooks.RestrictedHooks.http_request_args
+	'http_request_args',
+	static function ( array $args, string $url ): array {
+		if ( false === strpos( $url, 'onedesign/v1' ) ) {
+			return $args;
+		}
+
+		$args['reject_unsafe_urls'] = false;
+		return $args;
+	},
+	PHP_INT_MAX,
+	2,
+);
+
+// Reroute localhost requests to host.docker.internal for onedesign endpoints.
+add_filter(
+	'pre_http_request',
+	static function ( $preempt, array $args, string $url ) {
+		if ( false === strpos( $url, 'onedesign/v1' ) || false === strpos( $url, '://localhost' ) ) {
+			return $preempt;
+		}
+
+		$parsed = wp_parse_url( $url );
+		if ( ! is_array( $parsed ) || empty( $parsed['host'] ) ) {
+			return $preempt;
+		}
+
+		$original_host = $parsed['host'] . ( isset( $parsed['port'] ) ? ':' . (int) $parsed['port'] : '' );
+
+		$rewritten_url = str_replace( '://localhost', '://host.docker.internal', $url );
+
+		if ( empty( $args['headers'] ) || ! is_array( $args['headers'] ) ) {
+			$args['headers'] = [];
+		}
+		$args['headers']['Host'] = $original_host;
+		return wp_remote_request( $rewritten_url, $args );
+	},
+	PHP_INT_MAX,
+	3,
+);

--- a/tests/e2e/plugin/activation.spec.ts
+++ b/tests/e2e/plugin/activation.spec.ts
@@ -1,0 +1,76 @@
+/**
+ * WordPress dependencies
+ */
+import { expect, test } from '@wordpress/e2e-test-utils-playwright';
+
+test.describe( 'plugin activation', () => {
+	test( 'should activate and deactivate the plugin', async ( {
+		admin,
+		page,
+	} ) => {
+		await admin.visitAdminPage( '/plugins.php' );
+
+		// Helper to dismiss the onboarding modal if present.
+		const dismissOnboardingModal = async () => {
+			const modal = page.locator( '#onedesign-site-selection-modal' );
+			const backdrop = page.locator(
+				'body.onedesign-site-selection-modal'
+			);
+
+			if ( await modal.isVisible() ) {
+				await modal.evaluate( ( el ) => {
+					el.remove();
+				} );
+			}
+
+			if ( await backdrop.isVisible() ) {
+				await backdrop.evaluate( ( el ) => {
+					el.classList.remove( 'onedesign-site-selection-modal' );
+				} );
+			}
+		};
+
+		const pluginRow = page.locator(
+			'tr[data-plugin="onedesign/onedesign.php"]'
+		);
+		await expect( pluginRow ).toBeVisible();
+
+		// Dismiss modal before interacting with plugin row.
+		await dismissOnboardingModal();
+
+		// `hasText` does a substring match, so filtering by "Activate" would
+		// also match a "Deactivate" link — key off the action in the href instead.
+		const activateLink = pluginRow.locator( 'a[href*="action=activate"]' );
+		const deactivateLink = pluginRow.locator(
+			'a[href*="action=deactivate"]'
+		);
+
+		// wp-env activates mapped plugins on start, so the plugin may already
+		// be active — normalize to a known "inactive" starting state first.
+		if ( await deactivateLink.isVisible() ) {
+			await Promise.all( [
+				page.waitForURL( /plugins.php/ ),
+				deactivateLink.click(),
+			] );
+			await expect( activateLink ).toBeVisible( { timeout: 10000 } );
+			await dismissOnboardingModal();
+		}
+
+		await Promise.all( [
+			page.waitForURL( /plugins.php/ ),
+			activateLink.click(),
+		] );
+
+		await expect( deactivateLink ).toBeVisible( { timeout: 10000 } );
+
+		// Dismiss modal again after activation.
+		await dismissOnboardingModal();
+
+		await Promise.all( [
+			page.waitForURL( /plugins.php/ ),
+			deactivateLink.click(),
+		] );
+
+		await expect( activateLink ).toBeVisible( { timeout: 10000 } );
+	} );
+} );

--- a/tests/e2e/scaffold/plugin-preview.spec.ts
+++ b/tests/e2e/scaffold/plugin-preview.spec.ts
@@ -1,0 +1,57 @@
+/**
+ * WordPress dependencies
+ */
+import { expect, test } from '@wordpress/e2e-test-utils-playwright';
+
+/**
+ * Scaffold validation E2E.
+ *
+ * This is the local stand-in for the Playground PR preview: it proves the
+ * artifact the build/release/preview workflows produce actually loads in a
+ * real WordPress install — the plugin activates and its admin surface renders.
+ * If this passes, the scaffold's build output is functional end-to-end.
+ */
+test.describe( 'scaffold: built plugin loads', () => {
+	test( 'plugin is present and can be activated', async ( {
+		admin,
+		page,
+	} ) => {
+		await admin.visitAdminPage( '/plugins.php' );
+
+		const pluginRow = page.locator(
+			'tr[data-plugin="onedesign/onedesign.php"]'
+		);
+		await expect( pluginRow ).toBeVisible();
+
+		// Dismiss the onboarding modal if the plugin shows one on load.
+		const modal = page.locator( '#onedesign-site-selection-modal' );
+		if ( await modal.isVisible() ) {
+			await modal.evaluate( ( el ) => el.remove() );
+		}
+
+		const activate = pluginRow.locator( 'a', { hasText: 'Activate' } );
+		if ( await activate.isVisible() ) {
+			await Promise.all( [
+				page.waitForURL( /plugins.php/ ),
+				activate.click(),
+			] );
+		}
+
+		await expect(
+			pluginRow.locator( 'a', { hasText: 'Deactivate' } )
+		).toBeVisible( { timeout: 10000 } );
+	} );
+
+	test( 'admin surface renders without a fatal error', async ( {
+		admin,
+		page,
+	} ) => {
+		await admin.visitAdminPage( '/index.php' );
+
+		// A WordPress fatal renders "There has been a critical error".
+		await expect( page.locator( 'body' ) ).not.toContainText(
+			'There has been a critical error'
+		);
+		await expect( page.locator( '#wpadminbar' ) ).toBeVisible();
+	} );
+} );


### PR DESCRIPTION
## Summary
Add a Playwright end-to-end testing scaffold running against a dedicated wp-env
test environment, completing the shared OneSearch test baseline alongside the
Jest unit suite from #141.

## Changes
- **`playwright.config.ts`** (new): Playwright setup rooted at `testDir: ./tests/e2e`.
- **`.wp-env.test.json`** (new): an isolated test environment on **port 8889** with
  `WP_DEBUG` on and its own `debug-test.log`, so E2E runs never touch the dev
  container or its database.
- **E2E specs** (new):
  - `tests/e2e/plugin/activation.spec.ts` — activates and deactivates the plugin.
  - `tests/e2e/scaffold/plugin-preview.spec.ts` — asserts the built plugin is
    present and activatable, and that the admin surface renders without a fatal.
- **Scripts**: `test:e2e` (`wp-scripts test-playwright`) and `wp-env:test`
  (`wp-env --config=.wp-env.test.json`).
- **`@wordpress/env` `^10.39.0` → `^11.8.0`**: 10.x has no `--config` flag, so
  `wp-env:test` silently no-opped against the already-running dev container
  instead of starting a separate test environment. The bump is what makes the
  isolated test env actually work.
- Adds `@playwright/test` and pins `@wordpress/e2e-test-utils-playwright` to
  `1.46.0` (including an override for `@wordpress/scripts`) to keep the
  Playwright utils version consistent.
